### PR TITLE
chore: downgrade chart version to 1.0.30 and update resource limits f…

### DIFF
--- a/charts/vnext/Chart.yaml
+++ b/charts/vnext/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vnext
 description: vNext Workflow Orchestration Platform - A comprehensive microservices-based workflow orchestration system with built-in observability, service mesh, and high availability features
 type: application
-version: 1.0.31
+version: 1.0.30
 appVersion: "0.0.42"
 home: https://github.com/burgan-tech/vnext
 sources:

--- a/charts/vnext/templates/db-migrator/configmap.yaml
+++ b/charts/vnext/templates/db-migrator/configmap.yaml
@@ -29,5 +29,11 @@ data:
 
   APP_DOMAIN: {{ .Values.global.appDomain | quote }}
   DAPR_APP_ID: {{ printf "vnext-%s-db-migrator-app" ( .Values.global.appDomain ) | quote }}
+
+    # Application configuration
+  {{- if $dbMigrator.appEnvConfig }}
+  {{- range $key, $value := $dbMigrator.appEnvConfig }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
   
 {{- end }}

--- a/charts/vnext/templates/db-migrator/db-migrator-job.yaml
+++ b/charts/vnext/templates/db-migrator/db-migrator-job.yaml
@@ -10,6 +10,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/release-revision": "{{ .Release.Revision }}"
 spec:
   template:
     metadata:

--- a/charts/vnext/values.yaml
+++ b/charts/vnext/values.yaml
@@ -301,7 +301,11 @@ orchestrator:
     tls: []
   
   # Uses global.resources.default if empty
-  resources: {}
+  resources: 
+    default:
+      limits:
+        memory: 4Gi
+
   
   # Health check probes (uses global.probes if not specified)
   livenessProbe:


### PR DESCRIPTION
…or orchestrator [skip ci]

## Summary by Sourcery

Downgrade the vnext Helm chart version, configure orchestrator resource limits, and extend db-migrator configuration and metadata.

Enhancements:
- Set a default 4Gi memory limit for the orchestrator resources in the vnext values file.
- Allow db-migrator to consume additional application environment configuration from values via its ConfigMap.
- Annotate the db-migrator job with the Helm release revision for better traceability.
- Downgrade the vnext chart version from 1.0.31 to 1.0.30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Chart version reverted to 1.0.30

* **New Features**
  * Database migrator now supports custom environment configuration settings

* **Chores**
  * Added deployment tracking metadata
  * Updated orchestrator default memory allocation to 4Gi

<!-- end of auto-generated comment: release notes by coderabbit.ai -->