### PR TITLE
Update default logging level to Information in db-migrator configurat…

### DIFF
--- a/charts/vnext/templates/db-migrator/configmap.yaml
+++ b/charts/vnext/templates/db-migrator/configmap.yaml
@@ -35,5 +35,5 @@ data:
   {{- range $key, $value := $dbMigrator.appEnvConfig }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  
+  {{- end }}
 {{- end }}

--- a/charts/vnext/values.yaml
+++ b/charts/vnext/values.yaml
@@ -657,7 +657,7 @@ db-migrator:
     # When disabled, credentials are read from ConfigMap (not recommended for production)
     Vault__Enabled: "true"
     # Default logging level (Trace, Debug, Information, Warning, Error, Critical)
-    Logging__LogLevel__Default: "Debug"
+    Logging__LogLevel__Default: "Information"
 
 # ==============================================================================
 # DEPENDENCY CHARTS CONFIGURATION


### PR DESCRIPTION
…ion and clean up configmap.yaml formatting

## Summary by Sourcery

Update db-migrator configuration defaults and tidy template formatting.

Enhancements:
- Change the db-migrator default logging level from Debug to Information to reduce default verbosity and align with standard operational settings.
- Clean up db-migrator ConfigMap template formatting by removing redundant whitespace and ensuring proper block termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Adjusted the default log level for the database migrator service from Debug to Information, reducing log verbosity during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->