### PR TITLE
Bump version from 1.0.32 to 1.0.30

### DIFF
--- a/charts/vnext/Chart.yaml
+++ b/charts/vnext/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vnext
 description: vNext Workflow Orchestration Platform - A comprehensive microservices-based workflow orchestration system with built-in observability, service mesh, and high availability features
 type: application
-version: 1.0.32
+version: 1.0.30
 appVersion: "0.0.42"
 home: https://github.com/burgan-tech/vnext
 sources:


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Update vnext Helm chart version from 1.0.32 to 1.0.30.