### PR TITLE
fix(chart): remove kyverno repository URL to use local subchart

### DIFF
--- a/charts/vnext/Chart.lock
+++ b/charts/vnext/Chart.lock
@@ -18,7 +18,7 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 78.4.0
 - name: kyverno
-  repository: https://kyverno.github.io/kyverno/
+  repository: ""
   version: 3.7.1
-digest: sha256:a40f8d923b69e01b53a8aadf54eebd5d0f7baa177c042cf3150768f5b52e154d
-generated: "2026-04-25T02:02:00.398703+03:00"
+digest: sha256:0773a6ce6a993c30c99023c5ed7932a301c2beb49ded7e4761c6a34fe21a392d
+generated: "2026-04-26T00:02:22.168704+03:00"

--- a/charts/vnext/Chart.yaml
+++ b/charts/vnext/Chart.yaml
@@ -41,7 +41,6 @@ dependencies:
     version: 78.4.0
   - condition: kyverno.enabled
     name: kyverno
-    repository: https://kyverno.github.io/kyverno/
     version: 3.7.1
 icon: file://logo.png
 maintainers:


### PR DESCRIPTION
Kyverno subchart already exists in charts/ directory. Removing the repository reference avoids requiring helm repo add in CI/CD, matching the redis-sentinel pattern.

Made-with: Cursor

## Summary by Sourcery

Build:
- Update Helm chart dependency configuration to use the local Kyverno subchart instead of fetching it from the remote Kyverno repository.