### PR TITLE
redis-sentinel chart upgraded

### DIFF
--- a/charts/vnext/charts/redis-sentinel/Chart.yaml
+++ b/charts/vnext/charts/redis-sentinel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis-sentinel
 description: Redis with Sentinel for high availability - using official Redis image
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "7.4.1"
 keywords:
   - redis

--- a/charts/vnext/charts/redis-sentinel/templates/_helpers.tpl
+++ b/charts/vnext/charts/redis-sentinel/templates/_helpers.tpl
@@ -85,3 +85,27 @@ Return headless service name
 {{- printf "%s-headless" (include "redis-sentinel.fullname" .) -}}
 {{- end -}}
 
+{{/*
+Compute effective maxMemory for Redis:
+- If redis.maxMemory is non-empty, use it directly.
+- Else if redis.maxMemoryRatio is set, calculate as ratio * resources.redis.limits.memory.
+- Otherwise fall back to "0" (unlimited).
+Supported memory suffixes: Gi, Mi
+*/}}
+{{- define "redis-sentinel.effectiveMaxMemory" -}}
+{{- if .Values.redis.maxMemory -}}
+{{- .Values.redis.maxMemory -}}
+{{- else if .Values.redis.maxMemoryRatio -}}
+{{- $limit := .Values.resources.redis.limits.memory -}}
+{{- $memMB := 0 -}}
+{{- if hasSuffix "Gi" $limit -}}
+{{- $memMB = mulf (trimSuffix "Gi" $limit | float64) 1024 | int -}}
+{{- else if hasSuffix "Mi" $limit -}}
+{{- $memMB = trimSuffix "Mi" $limit | int -}}
+{{- end -}}
+{{- mulf ($memMB | float64) .Values.redis.maxMemoryRatio | int }}mb
+{{- else -}}
+0
+{{- end -}}
+{{- end -}}
+

--- a/charts/vnext/charts/redis-sentinel/templates/configmap-config.yaml
+++ b/charts/vnext/charts/redis-sentinel/templates/configmap-config.yaml
@@ -55,7 +55,7 @@ data:
     {{- end }}
     
     # Memory Management
-    maxmemory {{ .Values.redis.maxMemory }}
+    maxmemory {{ include "redis-sentinel.effectiveMaxMemory" . }}
     maxmemory-policy {{ .Values.redis.maxMemoryPolicy }}
     
     # Network
@@ -80,7 +80,11 @@ data:
     {{- else }}
     port {{ .Values.sentinel.port }}
     {{- end }}
+    {{- if .Values.redis.persistence.enabled }}
+    dir /data
+    {{- else }}
     dir /tmp
+    {{- end }}
     
     {{- if .Values.tls.enabled }}
     # TLS/SSL Configuration

--- a/charts/vnext/charts/redis-sentinel/templates/pdb.yaml
+++ b/charts/vnext/charts/redis-sentinel/templates/pdb.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     {{- include "redis-sentinel.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "redis-sentinel.selectorLabels" . | nindent 6 }}

--- a/charts/vnext/charts/redis-sentinel/values-examples/diskless-cache.yaml
+++ b/charts/vnext/charts/redis-sentinel/values-examples/diskless-cache.yaml
@@ -40,7 +40,7 @@ redis:
   password: ""
   
   # Redis port
-  port: 6679
+  port: 6379
   
   # Persistence configuration
   persistence:
@@ -251,7 +251,7 @@ tls:
   # TLS settings for Redis
   redis:
     # Port for TLS connections (if 0, uses redis.port)
-    port: 6679
+    port: 6379
     
     # Enable TLS for replication (must be true when TLS is enabled)
     replicationEnabled: true
@@ -265,7 +265,7 @@ tls:
   # TLS settings for Sentinel
   sentinel:
     # Port for TLS connections (if 0, uses sentinel.port)
-    port: 26679
+    port: 26379
     
     # Require client certificates
     authClients: false
@@ -281,7 +281,7 @@ sentinel:
   password: ""
   
   # Sentinel port
-  port: 26679
+  port: 26379
   
   # Quorum: number of Sentinels that need to agree about master being down
   # Typically (replicaCount / 2) + 1
@@ -305,10 +305,10 @@ sentinel:
 service:
   type: ClusterIP  # Keep as ClusterIP, external access uses separate LoadBalancer services
   redis:
-    port: 6679
+    port: 6379
     nodePort: ""
   sentinel:
-    port: 26679
+    port: 26379
     nodePort: ""
   annotations: {}
 
@@ -323,10 +323,10 @@ externalAccess:
     type: LoadBalancer
     
     # Port for Redis service
-    redisPort: 6679
+    redisPort: 6379
     
     # Port for Sentinel service
-    sentinelPort: 26679
+    sentinelPort: 26379
     
     # IMPORTANT: Configure one IP per pod (must match replicaCount = 3)
     # Replace with your actual LoadBalancer IPs from MetalLB or cloud provider

--- a/charts/vnext/charts/redis-sentinel/values.yaml
+++ b/charts/vnext/charts/redis-sentinel/values.yaml
@@ -57,7 +57,12 @@ redis:
   # Redis server configuration
   # CRITICAL: Set maxMemory to 80-90% of pod limit (3Gi = 3221MB)
   # Using 2560mb = 2.5GB = 78% of 3Gi pod limit
-  maxMemory: "2560mb"
+  # If maxMemoryRatio is set, maxMemory will be calculated as maxMemoryRatio * redis container limit
+  maxMemoryRatio: 0.78
+
+  # If maxMemory is set, maxMemoryRatio will be ignored
+  # maxMemory: "2560mb"
+  maxMemory: ""
   maxMemoryPolicy: "noeviction"
   appendonly: true
   
@@ -233,7 +238,10 @@ resources:
 # Pod disruption budget
 podDisruptionBudget:
   enabled: true
-  minAvailable: 2
+  # Prefer limiting disruptions to 1 pod at a time
+  maxUnavailable: 1
+  # For backward compatibility, minAvailable can still be set instead of maxUnavailable
+  # minAvailable: 2
 
 # Pod anti-affinity configuration
 # By default, uses soft anti-affinity with matchLabels for instance and name


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the redis-sentinel Helm chart with configurable memory limits, updated example ports, and safer disruption settings.

New Features:
- Allow Redis max memory to be derived from a configurable maxMemoryRatio and container memory limits, with a helper to compute the effective value.
- Support configuring pod disruption budgets using maxUnavailable in addition to the existing minAvailable option.

Enhancements:
- Set the Redis data directory for Sentinel to /data when persistence is enabled, falling back to /tmp when disabled.
- Align example ports in the diskless-cache values file to the standard Redis (6379) and Sentinel (26379) ports.
- Bump the redis-sentinel chart version from 1.0.0 to 1.1.0 to reflect the updated configuration options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pod Disruption Budget now supports `maxUnavailable` configuration for greater deployment flexibility.
  * Redis memory management now uses ratio-based configuration for improved resource utilization.

* **Bug Fixes**
  * Aligned port defaults to standard Redis ports (6379 for Redis, 26379 for Sentinel).

* **Chores**
  * Chart version updated to 1.1.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext-helm-charts/pull/14)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->