### PR TITLE
fix(db-migrator): run migrations as post-install hook and make worker…

### DIFF
--- a/charts/vnext/templates/db-migrator/configmap.yaml
+++ b/charts/vnext/templates/db-migrator/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "vnext.componentLabels" (dict "context" . "component" "db-migrator") | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
 data:
@@ -34,7 +34,7 @@ data:
   APP_DOMAIN: {{ .Values.global.appDomain | quote }}
   DAPR_APP_ID: {{ printf "vnext-%s-db-migrator-app" ( .Values.global.appDomain ) | quote }}
 
-    # Application configuration
+  # Application configuration
   {{- if $dbMigrator.appEnvConfig }}
   {{- range $key, $value := $dbMigrator.appEnvConfig }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/vnext/templates/db-migrator/db-migrator-job.yaml
+++ b/charts/vnext/templates/db-migrator/db-migrator-job.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "vnext.name" . }}-db-migrator
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation
     "checksum/config": {{ include (print $.Template.BasePath "/db-migrator/configmap.yaml") . | sha256sum }}
 spec:

--- a/charts/vnext/templates/orchestrator/deployment.yaml
+++ b/charts/vnext/templates/orchestrator/deployment.yaml
@@ -5,12 +5,10 @@ metadata:
   name: {{ include "vnext.fullname" . }}-orchestrator
   labels:
     {{- include "vnext.componentLabels" (dict "context" . "component" "orchestrator") | nindent 4 }}
-  {{- if .Values.dapr.enabled }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": before-hook-creation
-  {{- end }}
 spec:
   {{- if not .Values.orchestrator.autoscaling.enabled }}
   replicas: {{ .Values.orchestrator.replicaCount }}

--- a/charts/vnext/templates/worker-inbox/deployment.yaml
+++ b/charts/vnext/templates/worker-inbox/deployment.yaml
@@ -6,12 +6,10 @@ metadata:
   name: {{ include "vnext.fullname" . }}-worker-inbox
   labels:
     {{- include "vnext.componentLabels" (dict "context" . "component" "worker-inbox") | nindent 4 }}
-  {{- if .Values.dapr.enabled }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": before-hook-creation
-  {{- end }}
 spec:
   {{- if not $workerInbox.autoscaling.enabled }}
   replicas: {{ $workerInbox.replicaCount }}

--- a/charts/vnext/templates/worker-outbox/deployment.yaml
+++ b/charts/vnext/templates/worker-outbox/deployment.yaml
@@ -6,12 +6,10 @@ metadata:
   name: {{ include "vnext.fullname" . }}-worker-outbox
   labels:
     {{- include "vnext.componentLabels" (dict "context" . "component" "worker-outbox") | nindent 4 }}
-  {{- if .Values.dapr.enabled }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": before-hook-creation
-  {{- end }}
 spec:
   {{- if not $workerOutbox.autoscaling.enabled }}
   replicas: {{ $workerOutbox.replicaCount }}


### PR DESCRIPTION
…/orchestrator hooks unconditional

## Summary by Sourcery

Run db-migrator as a post-install/post-upgrade Helm hook and make orchestrator and worker deployments always use post-install/post-upgrade hooks.

Build:
- Update db-migrator ConfigMap and Job Helm hooks from pre-install/pre-upgrade to post-install/post-upgrade and adjust hook weight.
- Make orchestrator and worker deployments always register as post-install/post-upgrade hooks regardless of Dapr configuration.