### PR TITLE
Add post-delete to Helm hook delete policy

### DIFF
--- a/charts/vnext/templates/common/checker-job.yaml
+++ b/charts/vnext/templates/common/checker-job.yaml
@@ -10,7 +10,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,post-delete
 spec:
   template:
     spec:

--- a/charts/vnext/templates/common/vault-initializer/vault-initializer-job.yaml
+++ b/charts/vnext/templates/common/vault-initializer/vault-initializer-job.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,post-delete
 spec:
   template:
     spec:

--- a/charts/vnext/templates/db-migrator/db-migrator-job.yaml
+++ b/charts/vnext/templates/db-migrator/db-migrator-job.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,post-delete
     "checksum/config": {{ include (print $.Template.BasePath "/db-migrator/configmap.yaml") . | sha256sum }}
 spec:
   template:


### PR DESCRIPTION
Include "post-delete" in the "helm.sh/hook-delete-policy" annotation for several job hooks so Helm will remove hook resources on chart uninstall as well as before re-creating hooks. Updated files: charts/vnext/templates/common/checker-job.yaml, charts/vnext/templates/common/vault-initializer/vault-initializer-job.yaml, charts/vnext/templates/db-migrator/db-migrator-job.yaml. This ensures Jobs created by post-install/post-upgrade hooks are cleaned up during release deletion.

## Summary by Sourcery

Enhancements:
- Update checker, vault-initializer, and db-migrator job templates to delete hook resources on chart uninstall as well as before hook re-creation.