### PR TITLE
Update Vnext_Component_Version

### DIFF
--- a/charts/vnext/values.yaml
+++ b/charts/vnext/values.yaml
@@ -278,7 +278,7 @@ orchestrator:
     # Environment variables for the init job
     envConfig:
       # vNext core runtime version to initialize
-      VNEXT_COMPONENT_VERSION: "0.0.18"
+      VNEXT_COMPONENT_VERSION: "0.0.20"
       NPM_REGISTRY: "https://registry.npmjs.org/"
     ingress:
       enabled: false


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Helm chart values to use vNext component version 0.0.20 instead of 0.0.18.