### PR TITLE
plugin feature added

### DIFF
--- a/charts/vnext/Chart.yaml
+++ b/charts/vnext/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vnext
 description: vNext Workflow Orchestration Platform - A comprehensive microservices-based workflow orchestration system with built-in observability, service mesh, and high availability features
 type: application
-version: 1.0.68
+version: 1.0.69
 appVersion: "0.0.67"
 home: https://github.com/burgan-tech/vnext
 sources:

--- a/charts/vnext/templates/_helpers.tpl
+++ b/charts/vnext/templates/_helpers.tpl
@@ -346,6 +346,19 @@ Validate required values
   {{- end -}}
 {{- end -}}
 
+{{/* Validate plugins configuration */}}
+{{- if and .Values.orchestrator.plugins .Values.orchestrator.plugins.enabled -}}
+  {{- range $i, $repo := .Values.orchestrator.plugins.repos -}}
+    {{- if not $repo.url -}}
+      {{- $messages = append $messages (printf "orchestrator.plugins.repos[%d].url is required" $i) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $persistence := .Values.orchestrator.plugins.persistence | default dict -}}
+  {{- if and (not $persistence.existingClaim) (ne ($persistence.accessMode | default "ReadWriteMany") "ReadWriteMany") -}}
+    {{- $messages = append $messages "orchestrator.plugins.persistence.accessMode should be ReadWriteMany so multiple pods can share the plugins" -}}
+  {{- end -}}
+{{- end -}}
+
 {{/* Output validation errors if any */}}
 {{- if $messages -}}
 {{- printf "\nVALUES VALIDATION ERRORS:\n" -}}
@@ -422,4 +435,96 @@ Usage: {{ include "vnext.componentEnabled" (dict "component" .Values.orchestrato
 {{- else -}}
 true
 {{- end -}}
+{{- end -}}
+
+{{/*
+==============================================================================
+PLUGINS
+Helpers for fetching plugin git repositories (configured under
+.Values.orchestrator.plugins) into a ReadWriteMany PVC via a single populator
+Job (see templates/plugins/job.yaml). Consumers mount the PVC read-only.
+Each repo's contents are copied to the ROOT of mountPath. Fetching is
+idempotent via a per-repo `<hash>.done` marker; because the Job is the only
+writer, no cross-pod lock is needed.
+==============================================================================
+*/}}
+
+{{/*
+Whether plugin fetching is active (enabled and at least one repo defined).
+Usage: {{ if eq (include "vnext.plugins.enabled" .) "true" }}
+*/}}
+{{- define "vnext.plugins.enabled" -}}
+{{- $p := .Values.orchestrator.plugins | default dict -}}
+{{- if and $p.enabled $p.repos -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the generated Secret that holds inline (dev) plugin tokens.
+*/}}
+{{- define "vnext.plugins.secretName" -}}
+{{- printf "%s-plugin-tokens" (include "vnext.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the PVC backing the plugins (existingClaim override or generated).
+*/}}
+{{- define "vnext.plugins.claimName" -}}
+{{- $persistence := .Values.orchestrator.plugins.persistence | default dict -}}
+{{- if $persistence.existingClaim -}}
+{{- $persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-plugins" (include "vnext.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The shared PVC volume that holds the cloned plugins.
+Usage: {{ include "vnext.plugins.volume" . | nindent 8 }}
+*/}}
+{{- define "vnext.plugins.volume" -}}
+{{- if eq (include "vnext.plugins.enabled" .) "true" -}}
+- name: plugins
+  persistentVolumeClaim:
+    claimName: {{ include "vnext.plugins.claimName" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The read-only mount of the plugins volume into a consuming container.
+Usage: {{ include "vnext.plugins.volumeMount" . | nindent 12 }}
+*/}}
+{{- define "vnext.plugins.volumeMount" -}}
+{{- if eq (include "vnext.plugins.enabled" .) "true" -}}
+{{- $p := .Values.orchestrator.plugins -}}
+- name: plugins
+  mountPath: {{ $p.mountPath | default "/app/assemblies" }}
+  readOnly: true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Token env vars for the plugin-fetcher Job. Each repo's token comes from the
+resolved secret (per-repo existingSecret -> defaultAuth -> generated inline
+secret) and never appears in the rendered manifest as plaintext.
+Usage: {{ include "vnext.plugins.tokenEnv" . | nindent 12 }}
+*/}}
+{{- define "vnext.plugins.tokenEnv" -}}
+{{- $p := .Values.orchestrator.plugins -}}
+{{- $genSecret := include "vnext.plugins.secretName" . -}}
+{{- range $i, $repo := $p.repos }}
+{{- $auth := $repo.auth | default $p.defaultAuth | default dict }}
+{{- if $auth.existingSecret }}
+- name: PLUGIN_TOKEN_{{ $i }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $auth.existingSecret }}
+      key: {{ $auth.tokenKey | default "token" }}
+{{- else if $auth.token }}
+- name: PLUGIN_TOKEN_{{ $i }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $genSecret }}
+      key: {{ printf "plugin-%d-token" $i }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/vnext/templates/orchestrator/deployment.yaml
+++ b/charts/vnext/templates/orchestrator/deployment.yaml
@@ -68,13 +68,21 @@ spec:
           resources:
             {{- $resources | nindent 12 }}
           {{- end }}
-          {{- with .Values.orchestrator.volumeMounts }}
+          {{- $pluginMount := include "vnext.plugins.volumeMount" . }}
+          {{- if or .Values.orchestrator.volumeMounts $pluginMount }}
           volumeMounts:
+            {{- with .Values.orchestrator.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- $pluginMount | nindent 12 }}
           {{- end }}
-      {{- with .Values.orchestrator.volumes }}
+      {{- $pluginVol := include "vnext.plugins.volume" . }}
+      {{- if or .Values.orchestrator.volumes $pluginVol }}
       volumes:
+        {{- with .Values.orchestrator.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- $pluginVol | nindent 8 }}
       {{- end }}
       {{- with .Values.orchestrator.nodeSelector }}
       nodeSelector:

--- a/charts/vnext/templates/plugins/job.yaml
+++ b/charts/vnext/templates/plugins/job.yaml
@@ -1,0 +1,80 @@
+{{- /*
+Single populator Job that fetches all configured plugin repos into the shared
+RWX PVC. Runs as a post-install/post-upgrade hook with a low weight so it
+completes BEFORE the consuming workloads (e.g. orchestrator, weight 4) start.
+
+Being the ONLY writer, it needs no cross-pod lock: idempotency is a per-repo
+`<hash>.done` marker created LAST, after a successful clone+copy. If the Job
+dies mid-fetch no marker is written, so the next attempt re-fetches; a genuine
+clone failure (set -e) fails the Job and surfaces as a failed Helm release
+instead of silently starting pods with missing plugins.
+*/ -}}
+{{- if eq (include "vnext.plugins.enabled" .) "true" }}
+{{- $p := .Values.orchestrator.plugins }}
+{{- $mountPath := $p.mountPath | default "/app/assemblies" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "vnext.fullname" . }}-plugin-fetcher
+  labels:
+    {{- include "vnext.componentLabels" (dict "context" . "component" "plugin-fetcher") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "vnext.componentLabels" (dict "context" . "component" "plugin-fetcher") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      {{- with (coalesce .Values.orchestrator.imagePullSecrets .Values.global.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: plugin-fetcher
+          image: "{{ $p.image.repository | default "alpine/git" }}:{{ $p.image.tag | default "latest" }}"
+          imagePullPolicy: {{ $p.image.pullPolicy | default .Values.global.imagePullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              PLUGIN_DIR="{{ $mountPath }}"
+              META="$PLUGIN_DIR/.plugin-meta"
+              mkdir -p "$META"
+              {{- range $i, $repo := $p.repos }}
+              URL="{{ $repo.url }}"
+              echo "Plugin: $URL{{ with $repo.ref }} @ {{ . }}{{ end }}"
+              MARKER="$META/{{ sha256sum (printf "%s@%s" $repo.url ($repo.ref | default "HEAD")) | trunc 16 }}.done"
+              TOKEN="${PLUGIN_TOKEN_{{ $i }}:-}"
+              {{- if $p.forceRefresh }}
+              rm -f "$MARKER"
+              {{- end }}
+              if [ -f "$MARKER" ]; then
+                echo "  already present, skipping (set forceRefresh to re-fetch)"
+              else
+                if [ -n "$TOKEN" ]; then URL=$(printf '%s' "$URL" | sed -E "s#^(https?://)#\1${TOKEN}@#"); fi
+                rm -rf /tmp/plugin-src
+                git clone --depth 1 {{ with $repo.ref }}--branch "{{ . }}" {{ end }}"$URL" /tmp/plugin-src
+                rm -rf /tmp/plugin-src/.git
+                cp -a "/tmp/plugin-src{{ with $repo.subPath }}/{{ . }}{{ end }}/." "$PLUGIN_DIR/"
+                rm -rf /tmp/plugin-src
+                touch "$MARKER"
+                echo "  done."
+              fi
+              {{- end }}
+              echo "All plugins ready under $PLUGIN_DIR"
+          env:
+            {{- include "vnext.plugins.tokenEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: plugins
+              mountPath: {{ $mountPath }}
+      volumes:
+        - name: plugins
+          persistentVolumeClaim:
+            claimName: {{ include "vnext.plugins.claimName" . }}
+{{- end }}

--- a/charts/vnext/templates/plugins/pvc.yaml
+++ b/charts/vnext/templates/plugins/pvc.yaml
@@ -1,0 +1,26 @@
+{{- /*
+ReadWriteMany PVC that holds the cloned plugins. Created only when plugins are
+enabled, persistence is enabled, and no existingClaim is supplied. As a normal
+(non-hook) resource it is created before the post-install orchestrator hook, so
+the claim exists by the time the init container mounts it.
+*/ -}}
+{{- if eq (include "vnext.plugins.enabled" .) "true" }}
+{{- $persistence := .Values.orchestrator.plugins.persistence | default dict }}
+{{- if and $persistence.enabled (not $persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "vnext.plugins.claimName" . }}
+  labels:
+    {{- include "vnext.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ $persistence.accessMode | default "ReadWriteMany" }}
+  resources:
+    requests:
+      storage: {{ $persistence.size | default "1Gi" }}
+  {{- if $persistence.storageClass }}
+  storageClassName: {{ $persistence.storageClass }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/vnext/templates/plugins/secret.yaml
+++ b/charts/vnext/templates/plugins/secret.yaml
@@ -1,0 +1,29 @@
+{{- /*
+Generated Secret holding inline (dev-only) plugin tokens.
+Only repos whose resolved auth uses an inline `token` (i.e. no existingSecret)
+contribute a key here, named "plugin-<index>-token". In production, point each
+repo at an existingSecret and this Secret is not rendered.
+*/ -}}
+{{- if eq (include "vnext.plugins.enabled" .) "true" }}
+{{- $p := .Values.orchestrator.plugins }}
+{{- $inline := dict }}
+{{- range $i, $repo := $p.repos }}
+  {{- $auth := $repo.auth | default $p.defaultAuth | default dict }}
+  {{- if and (not $auth.existingSecret) $auth.token }}
+    {{- $_ := set $inline (printf "plugin-%d-token" $i) $auth.token }}
+  {{- end }}
+{{- end }}
+{{- if $inline }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "vnext.plugins.secretName" . }}
+  labels:
+    {{- include "vnext.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := $inline }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/vnext/values.yaml
+++ b/charts/vnext/values.yaml
@@ -223,6 +223,7 @@ global:
     # Run container as non-root user (may need adjustment for some images)
     runAsNonRoot: false
 
+
 # ==============================================================================
 # SERVICE ACCOUNT CONFIGURATION
 # Kubernetes service account for pod authentication
@@ -401,6 +402,72 @@ orchestrator:
     Logging__LogLevel__Default: "Debug"
     # SignalR hub configuration for real-time communication
     SignalR__AppId: "http://localhost:6203"
+
+  # ---------------------------------------------------------------------------
+  # Plugins
+  # A single populator Job (post-install/post-upgrade hook) clones these repos
+  # into a ReadWriteMany PVC before the orchestrator starts; the orchestrator
+  # mounts the PVC read-only. Each repo's contents are copied to the ROOT of
+  # `mountPath` (no per-repo sub-directory). Fetching is idempotent: a repo
+  # already present in the PVC is not re-cloned unless `forceRefresh` is set.
+  # ---------------------------------------------------------------------------
+  plugins:
+    # Enable or disable plugin fetching entirely
+    enabled: false
+
+    # Where the plugins PVC is mounted inside the container(s)
+    mountPath: /app/assemblies
+
+    # Re-clone every repo on each rollout even if already present in the PVC
+    forceRefresh: false
+
+    # Image used by the init container to clone the repositories
+    image:
+      repository: alpine/git
+      tag: latest
+      # If empty, falls back to global.imagePullPolicy
+      pullPolicy: ""
+
+    # Shared storage that holds the cloned plugins.
+    # MUST be ReadWriteMany so multiple replicas/services can mount it at once.
+    persistence:
+      # Create a PVC (set false + existingClaim to reuse one)
+      enabled: true
+      # Reuse an existing RWX PVC instead of creating one
+      existingClaim: ""
+      # StorageClass that supports ReadWriteMany (e.g. nfs, azurefile, efs-sc).
+      # Empty uses the cluster default — which often does NOT support RWX.
+      storageClass: ""
+      accessMode: ReadWriteMany
+      size: 1Gi
+
+    # Default authentication applied to every repo that does not define its own
+    # `auth` block. In production prefer `existingSecret`; `token` is for local
+    # development only and must never hold a real credential in committed values.
+    defaultAuth:
+      # Name of an existing Kubernetes Secret holding the git token/PAT
+      existingSecret: ""
+      # Key inside that secret
+      tokenKey: token
+      # Inline token (dev only). Synthesized into a generated Secret at install
+      # time. Leave empty in committed values.
+      token: ""
+
+    # Repositories to fetch. Only `url` is required. Contents land at the root
+    # of `mountPath`, so ensure repos do not produce conflicting file paths.
+    repos: []
+      # - url: https://tfs.burgan.com.tr/tfs/DefaultCollection/PROJECT/_git/vnext
+      #   # Branch or tag to check out (optional; defaults to repo HEAD)
+      #   ref: master
+      #   # Sub-directory inside the repo to copy (optional; empty = repo root)
+      #   subPath: plugins
+      #   # Per-repo auth override. Omit to inherit defaultAuth.
+      #   auth:
+      #     existingSecret: vnext-plugin-tokens
+      #     tokenKey: vnext-core-token
+      # - url: https://tfs.burgan.com.tr/tfs/DefaultCollection/MustafaTest/_git/vnext-plugins
+      #   ref: main
+      #   # No auth block -> inherits defaultAuth (public repo if defaultAuth empty)
 
 # ==============================================================================
 # EXECUTION SERVICE CONFIGURATION


### PR DESCRIPTION
## Summary by Sourcery

Add Helm-based plugin fetching support for the orchestrator using a shared PVC and initialization job.

New Features:
- Introduce configurable orchestrator.plugins section for defining plugin repositories, authentication, and shared storage.
- Add Helm helpers and templates to mount a shared plugins PVC into the orchestrator deployment when enabled.
- Add a post-install/upgrade Job to clone configured plugin git repositories into a ReadWriteMany volume.
- Generate a Secret for inline plugin tokens and a PVC for plugin storage when required.

Enhancements:
- Extend Helm values validation to cover orchestrator.plugins configuration and enforce RWX access mode for plugin storage.

Build:
- Bump vnext chart version from 1.0.68 to 1.0.69.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional plugin fetching support during deployment, including shared storage, per-repository configuration, and automatic loading into the app.
  * Added support for secure token handling through Kubernetes secrets, with optional inline tokens for development use.
* **Bug Fixes**
  * Added configuration checks to help catch missing plugin URLs and ensure shared storage is set correctly for multi-pod use.
* **Chores**
  * Updated the chart version to `1.0.69`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->