### PR TITLE
plugin names options added

### DIFF
--- a/charts/vnext/templates/_helpers.tpl
+++ b/charts/vnext/templates/_helpers.tpl
@@ -440,12 +440,13 @@ true
 {{/*
 ==============================================================================
 PLUGINS
-Helpers for fetching plugin git repositories (configured under
-.Values.orchestrator.plugins) into a ReadWriteMany PVC via a single populator
-Job (see templates/plugins/job.yaml). Consumers mount the PVC read-only.
-Each repo's contents are copied to the ROOT of mountPath. Fetching is
-idempotent via a per-repo `<hash>.done` marker; because the Job is the only
-writer, no cross-pod lock is needed.
+Helpers for the plugins feature (configured under .Values.orchestrator.plugins).
+A single populator Job (see templates/plugins/job.yaml) reconciles a
+ReadWriteMany PVC to match the `pluginNames` allowlist of DLL file names;
+consumers mount the PVC read-only. Missing DLLs are copied flat into mountPath
+(last repo wins on duplicate names); DLLs already present are left untouched
+unless forceRefresh is set; files dropped from the list are removed. Because
+the Job is the only writer, no lock is needed.
 ==============================================================================
 */}}
 

--- a/charts/vnext/templates/plugins/job.yaml
+++ b/charts/vnext/templates/plugins/job.yaml
@@ -1,13 +1,21 @@
 {{- /*
-Single populator Job that fetches all configured plugin repos into the shared
-RWX PVC. Runs as a post-install/post-upgrade hook with a low weight so it
-completes BEFORE the consuming workloads (e.g. orchestrator, weight 4) start.
+Single populator Job that reconciles the shared RWX PVC to match the
+`pluginNames` allowlist of DLL file names. Runs as a post-install/post-upgrade
+hook with a low weight so it completes BEFORE the consuming workloads
+(orchestrator, weight 4).
 
-Being the ONLY writer, it needs no cross-pod lock: idempotency is a per-repo
-`<hash>.done` marker created LAST, after a successful clone+copy. If the Job
-dies mid-fetch no marker is written, so the next attempt re-fetches; a genuine
-clone failure (set -e) fails the Job and surfaces as a failed Helm release
-instead of silently starting pods with missing plugins.
+Being the ONLY writer, it needs no cross-pod lock. Each run:
+  1. INSTALLS the listed DLLs that are MISSING from the PVC (a DLL already
+     present is left untouched unless forceRefresh is set, so nothing is
+     re-downloaded and no repo is cloned when nothing is missing). A missing
+     DLL is found by a recursive search under each repo's <subPath> and copied
+     FLAT into <mountPath>/<name>; repos are processed in list order so the
+     LAST repo that contains a given name wins.
+  2. PRUNES: deletes any file in the PVC that is not in `pluginNames`.
+  3. VERIFIES: a listed name not found in any repo fails the Job (set -e),
+     surfacing as a failed Helm release instead of silently missing a plugin.
+Copies are atomic (temp file + rename), so each DLL is either fully present or
+absent — no partial-copy state.
 */ -}}
 {{- if eq (include "vnext.plugins.enabled" .) "true" }}
 {{- $p := .Values.orchestrator.plugins }}
@@ -44,30 +52,73 @@ spec:
             - |
               set -eu
               PLUGIN_DIR="{{ $mountPath }}"
-              META="$PLUGIN_DIR/.plugin-meta"
-              mkdir -p "$META"
-              {{- range $i, $repo := $p.repos }}
-              URL="{{ $repo.url }}"
-              echo "Plugin: $URL{{ with $repo.ref }} @ {{ . }}{{ end }}"
-              MARKER="$META/{{ sha256sum (printf "%s@%s" $repo.url ($repo.ref | default "HEAD")) | trunc 16 }}.done"
-              TOKEN="${PLUGIN_TOKEN_{{ $i }}:-}"
-              {{- if $p.forceRefresh }}
-              rm -f "$MARKER"
-              {{- end }}
-              if [ -f "$MARKER" ]; then
-                echo "  already present, skipping (set forceRefresh to re-fetch)"
+              mkdir -p "$PLUGIN_DIR"
+              DESIRED="{{ $p.pluginNames | default list | join " " }}"
+              echo "Desired plugins: ${DESIRED:-<none>}"
+
+              is_desired() {
+                for d in $DESIRED; do [ "$d" = "$1" ] && return 0; done
+                return 1
+              }
+
+              # 1. Work out which DLLs still need fetching. A DLL already in the
+              #    PVC is skipped (not re-downloaded) unless forceRefresh is set.
+              NEED=""
+              for name in $DESIRED; do
+                {{- if $p.forceRefresh }}
+                NEED="$NEED $name"
+                {{- else }}
+                [ -e "$PLUGIN_DIR/$name" ] || NEED="$NEED $name"
+                {{- end }}
+              done
+
+              if [ -z "$NEED" ]; then
+                echo "All desired plugins already present; skipping download."
               else
+                echo "Plugins to fetch:$NEED"
+                # Clone every repo in order; later repos overwrite earlier ones
+                # (last listed repo wins on duplicate names).
+                {{- range $i, $repo := $p.repos }}
+                URL="{{ $repo.url }}"
+                TOKEN="${PLUGIN_TOKEN_{{ $i }}:-}"
+                echo "Searching repo: $URL{{ with $repo.ref }} @ {{ . }}{{ end }}"
                 if [ -n "$TOKEN" ]; then URL=$(printf '%s' "$URL" | sed -E "s#^(https?://)#\1${TOKEN}@#"); fi
                 rm -rf /tmp/plugin-src
                 git clone --depth 1 {{ with $repo.ref }}--branch "{{ . }}" {{ end }}"$URL" /tmp/plugin-src
-                rm -rf /tmp/plugin-src/.git
-                cp -a "/tmp/plugin-src{{ with $repo.subPath }}/{{ . }}{{ end }}/." "$PLUGIN_DIR/"
+                SRC="/tmp/plugin-src{{ with $repo.subPath }}/{{ . }}{{ end }}"
+                for name in $NEED; do
+                  found=$(find "$SRC" -type f -name "$name" 2>/dev/null | head -n 1 || true)
+                  if [ -n "$found" ]; then
+                    echo "  installing: $name"
+                    cp -f "$found" "$PLUGIN_DIR/.$name.tmp"
+                    mv -f "$PLUGIN_DIR/.$name.tmp" "$PLUGIN_DIR/$name"
+                  fi
+                done
                 rm -rf /tmp/plugin-src
-                touch "$MARKER"
-                echo "  done."
+                {{- end }}
               fi
-              {{- end }}
-              echo "All plugins ready under $PLUGIN_DIR"
+
+              # 2. Prune: remove any file not in the allowlist
+              for path in "$PLUGIN_DIR"/* "$PLUGIN_DIR"/.*; do
+                [ -e "$path" ] || continue
+                bn=$(basename "$path")
+                case "$bn" in .|..) continue ;; esac
+                if ! is_desired "$bn"; then
+                  echo "Pruning removed plugin: $bn"
+                  rm -rf "$path"
+                fi
+              done
+
+              # 3. Verify every desired plugin was installed
+              MISSING=""
+              for name in $DESIRED; do
+                [ -e "$PLUGIN_DIR/$name" ] || MISSING="$MISSING $name"
+              done
+              if [ -n "$MISSING" ]; then
+                echo "ERROR: plugins not found in any repo:$MISSING" >&2
+                exit 1
+              fi
+              echo "Plugins reconciled under $PLUGIN_DIR to: ${DESIRED:-<none>}"
           env:
             {{- include "vnext.plugins.tokenEnv" . | nindent 12 }}
           volumeMounts:

--- a/charts/vnext/values.yaml
+++ b/charts/vnext/values.yaml
@@ -405,23 +405,41 @@ orchestrator:
 
   # ---------------------------------------------------------------------------
   # Plugins
-  # A single populator Job (post-install/post-upgrade hook) clones these repos
-  # into a ReadWriteMany PVC before the orchestrator starts; the orchestrator
-  # mounts the PVC read-only. Each repo's contents are copied to the ROOT of
-  # `mountPath` (no per-repo sub-directory). Fetching is idempotent: a repo
-  # already present in the PVC is not re-cloned unless `forceRefresh` is set.
+  # A single populator Job (post-install/post-upgrade hook) reconciles a
+  # ReadWriteMany PVC before the orchestrator starts; the orchestrator mounts
+  # the PVC read-only.
+  #
+  # A "plugin" is a DLL file. `pluginNames` is an allowlist of DLL file names.
+  # Each run the Job installs the listed DLLs that are MISSING from the PVC (a
+  # DLL already present is left untouched, so nothing is re-downloaded), then
+  # PRUNES any file in the PVC that is not listed. To fetch a missing DLL it
+  # clones the repos in list order and copies the match FLAT into `mountPath`;
+  # if the same name exists in more than one repo, the LAST repo wins. A listed
+  # name not found in any repo fails the Job. Set `forceRefresh: true` to
+  # re-download every listed DLL even if already present.
   # ---------------------------------------------------------------------------
   plugins:
     # Enable or disable plugin fetching entirely
     enabled: false
 
-    # Where the plugins PVC is mounted inside the container(s)
+    # Where the plugin DLLs are placed inside the container(s)
     mountPath: /app/assemblies
 
-    # Re-clone every repo on each rollout even if already present in the PVC
+    # Allowlist of plugin DLL file names to install (exact file names, including
+    # the .dll extension). The Job searches each repo's `subPath` recursively
+    # for these files. Files in the PVC that are NOT listed here are removed on
+    # the next run. Empty list = no plugins installed (existing ones are pruned).
+    pluginNames: []
+      # - Vnext.PluginA.dll
+      # - Vnext.PluginC.dll
+
+    # By default a DLL already present in the PVC is left untouched (not
+    # re-downloaded), so repos are only cloned when something is missing.
+    # Set true to re-download every listed DLL even if already present — this
+    # also re-applies the "last repo wins" rule for duplicate names.
     forceRefresh: false
 
-    # Image used by the init container to clone the repositories
+    # Image used by the Job to clone the repositories
     image:
       repository: alpine/git
       tag: latest
@@ -453,19 +471,22 @@ orchestrator:
       # time. Leave empty in committed values.
       token: ""
 
-    # Repositories to fetch. Only `url` is required. Contents land at the root
-    # of `mountPath`, so ensure repos do not produce conflicting file paths.
+    # Source repositories that contain the plugin DLLs. Only `url` is required.
+    # Each repo is searched (under its `subPath`) for the file names in
+    # `pluginNames`. Repos are processed in order, so if the same file name
+    # exists in multiple repos, the LAST one listed here wins.
     repos: []
-      # - url: https://tfs.burgan.com.tr/tfs/DefaultCollection/PROJECT/_git/vnext
+      # - url: https://github.com.tr/_git/vnext
       #   # Branch or tag to check out (optional; defaults to repo HEAD)
       #   ref: master
-      #   # Sub-directory inside the repo to copy (optional; empty = repo root)
+      #   # Directory inside the repo to search for the DLLs, recursively
+      #   # (optional; empty = repo root)
       #   subPath: plugins
       #   # Per-repo auth override. Omit to inherit defaultAuth.
       #   auth:
       #     existingSecret: vnext-plugin-tokens
       #     tokenKey: vnext-core-token
-      # - url: https://tfs.burgan.com.tr/tfs/DefaultCollection/MustafaTest/_git/vnext-plugins
+      # - url: https://github.com.tr/_git/vnext
       #   ref: main
       #   # No auth block -> inherits defaultAuth (public repo if defaultAuth empty)
 


### PR DESCRIPTION
## Summary by Sourcery

Rework the plugins Job and configuration to reconcile a shared PVC against an allowlist of plugin DLL names, installing missing DLLs from configured repos, pruning unlisted files, and failing when requested plugins cannot be found.

New Features:
- Introduce a pluginNames allowlist to control which DLL files are installed into the plugins PVC.
- Add forceRefresh behavior for plugins to optionally re-download and re-apply repository ordering rules on each run.

Enhancements:
- Redesign the plugins Job logic to install only desired DLLs, prune extraneous files, and verify all requested plugins are present.
- Clarify and expand Helm values and helper template documentation around plugin PVC reconciliation, DLL discovery, and repository processing order.

Documentation:
- Update orchestrator plugin configuration documentation to describe pluginNames, pruning behavior, repository search rules, and forceRefresh semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin handling now uses an allowlist of plugin names, with missing plugins automatically installed and unlisted files removed.
  * Duplicate plugin names across repositories now follow a clear “last one wins” rule.

* **Bug Fixes**
  * Improved plugin reconciliation so existing plugins are preserved unless refresh is requested.
  * Clearer errors are shown when a requested plugin cannot be found in any configured repository.

* **Documentation**
  * Updated plugin configuration guidance to match the new reconciliation and repository search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->