### PR TITLE
feat: Dapr resiliency + dynamic pubsub/subscription components

### DIFF
--- a/charts/vnext/docs/README_EN.md
+++ b/charts/vnext/docs/README_EN.md
@@ -201,6 +201,53 @@ global:
     grpcPort: "42111"
 ```
 
+#### Dapr Resiliency
+
+The chart ships two Dapr `Resiliency` policies out of the box (rendered automatically, no configuration required). Each installs a circuit breaker that fast-fails cross-service invocations instead of stacking timeouts, and is scoped to a single sidecar:
+
+| Resiliency | Scoped to (sidecar) | Protects call | App ID pattern |
+|------------|---------------------|---------------|----------------|
+| `vnext-orchestration-resiliency` | Orchestrator | Orchestration → Execution task invocation | `vnext-<appDomain>-app` → `vnext-<appDomain>-execution-app` |
+| `vnext-inbox-resiliency` | Worker-Inbox | Inbox → Orchestration forwards | `vnext-<appDomain>-worker-inbox-app` → `vnext-<appDomain>-app` |
+
+Both use `invocationBreaker`: 5 consecutive failures open the circuit for 30s, then a single probe request decides whether to close it. No retry or timeout policy is applied on purpose — retry/timeout ownership stays in the application layer. App IDs are derived from `global.appDomain`.
+
+#### Event-Driven Pub/Sub and Subscriptions
+
+For event-driven workflows you can declare additional Dapr pub/sub components and topic subscriptions from values. Both are rendered as Dapr resources **scoped to the orchestrator (`vnext-<appDomain>-app`) sidecar**.
+
+```yaml
+global:
+  # Pub/sub components — the `name` is used verbatim as the Dapr component name.
+  pubsubComponents:
+    - name: kafka-events
+      spec:
+        type: pubsub.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka:9092"
+          - name: authType
+            value: none
+
+  # Subscriptions (Dapr Subscription v2alpha1). `pubsubname` must match a pubsubComponents[].name.
+  subscriptionComponents:
+    - name: order-created-sub
+      spec:
+        pubsubname: kafka-events
+        topic: order.created
+        routes:
+          default: /events/order-created
+          # rules:
+          #   - match: 'event.type == "priority"'
+          #     path: /events/order-created-priority
+        # deadLetterTopic: order.created.DLQ
+        # metadata:
+        #   rawPayload: "true"
+```
+
+Both lists default to `[]` (nothing rendered). This mirrors the existing `global.notificationComponents` pattern for dynamic notification bindings.
+
 #### Telemetry Configuration
 
 ```yaml

--- a/charts/vnext/docs/README_TR.md
+++ b/charts/vnext/docs/README_TR.md
@@ -201,6 +201,53 @@ global:
     grpcPort: "42111"
 ```
 
+#### Dapr Resiliency (Dayanıklılık)
+
+Chart, kutudan çıktığı gibi iki Dapr `Resiliency` politikasıyla gelir (otomatik oluşturulur, yapılandırma gerektirmez). Her biri, servisler arası çağrılarda zaman aşımlarının üst üste binmesi yerine devreyi hızlıca açan bir circuit breaker kurar ve tek bir sidecar'a scope'lanır:
+
+| Resiliency | Scope (sidecar) | Korunan çağrı | App ID deseni |
+|------------|-----------------|---------------|---------------|
+| `vnext-orchestration-resiliency` | Orchestrator | Orchestration → Execution task çağrısı | `vnext-<appDomain>-app` → `vnext-<appDomain>-execution-app` |
+| `vnext-inbox-resiliency` | Worker-Inbox | Inbox → Orchestration yönlendirmeleri | `vnext-<appDomain>-worker-inbox-app` → `vnext-<appDomain>-app` |
+
+İkisi de `invocationBreaker` kullanır: 5 ardışık hata devreyi 30 saniye açar, ardından tek bir prob isteği devrenin kapanıp kapanmayacağına karar verir. Bilinçli olarak retry veya timeout politikası uygulanmaz — retry/timeout sorumluluğu uygulama katmanında kalır. App ID'ler `global.appDomain` değerinden türetilir.
+
+#### Olay Tabanlı Pub/Sub ve Subscription'lar
+
+Olay tabanlı (event-driven) workflow'lar için değerler üzerinden ek Dapr pub/sub bileşenleri ve topic subscription'ları tanımlayabilirsiniz. İkisi de **orchestrator (`vnext-<appDomain>-app`) sidecar'ına scope'lanmış** Dapr kaynakları olarak oluşturulur.
+
+```yaml
+global:
+  # Pub/sub bileşenleri — `name` değeri Dapr bileşen adı olarak birebir kullanılır.
+  pubsubComponents:
+    - name: kafka-events
+      spec:
+        type: pubsub.kafka
+        version: v1
+        metadata:
+          - name: brokers
+            value: "kafka:9092"
+          - name: authType
+            value: none
+
+  # Subscription'lar (Dapr Subscription v2alpha1). `pubsubname`, pubsubComponents[].name ile eşleşmelidir.
+  subscriptionComponents:
+    - name: order-created-sub
+      spec:
+        pubsubname: kafka-events
+        topic: order.created
+        routes:
+          default: /events/order-created
+          # rules:
+          #   - match: 'event.type == "priority"'
+          #     path: /events/order-created-priority
+        # deadLetterTopic: order.created.DLQ
+        # metadata:
+        #   rawPayload: "true"
+```
+
+Her iki liste de varsayılan olarak `[]`'dir (hiçbir kaynak oluşturulmaz). Bu, dinamik notification binding'leri için mevcut `global.notificationComponents` desenini takip eder.
+
 #### Telemetri Yapılandırması
 
 ```yaml

--- a/charts/vnext/templates/common/common-dapr-components/resiliency-inbox.yaml
+++ b/charts/vnext/templates/common/common-dapr-components/resiliency-inbox.yaml
@@ -1,0 +1,34 @@
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: vnext-inbox-resiliency
+# Loaded by the worker-inbox sidecar only.
+scopes:
+- {{ printf "vnext-%s-worker-inbox-app" .Values.global.appDomain | quote }}
+spec:
+  policies:
+    circuitBreakers:
+      # When Orchestration is down, fail forwards fast and let the inbox's bounded redelivery
+      # + dead-letter own durability instead of stacking 60s timeouts. The breaker only
+      # short-circuits; it never re-sends a forward.
+      invocationBreaker:
+        maxRequests: 1
+        timeout: 30s
+        trip: consecutiveFailures >= 5
+  targets:
+    apps:
+      # Inbox worker → Orchestration internal forwards (subflow lifecycle, transition
+      # continuations).
+      #
+      # NO retry policy on purpose. The forwarder (DaprOrchestrationForwarder) already owns the
+      # at-least-once contract at the message level: transient statuses (>= 500, 408, 429)
+      # rethrow so the inbox re-delivers, permanent 4xx are dropped. A sidecar retry here would
+      # both retry the permanent 4xx (delaying the forwarder's drop decision) and duplicate the
+      # inbox's own redelivery of transient failures — cross-layer amplification. Dapr retry
+      # also cannot tell an app error response from an unreachable-app failure by status code
+      # (`matching.httpStatusCodes` filters by code, not origin; an empty set retries all HTTP
+      # errors), so classification stays in the forwarder where the distinction is known.
+      #
+      # No timeout policy: OrchestrationApi:InvocationTimeoutSeconds (60s) owns the per-call budget.
+      {{ printf "vnext-%s-app" .Values.global.appDomain }}:
+        circuitBreaker: invocationBreaker

--- a/charts/vnext/templates/common/common-dapr-components/resiliency-orchestration.yaml
+++ b/charts/vnext/templates/common/common-dapr-components/resiliency-orchestration.yaml
@@ -1,0 +1,41 @@
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: vnext-orchestration-resiliency
+# Loaded by the orchestrator (vnext-app) sidecar only.
+scopes:
+- {{ printf "vnext-%s-app" .Values.global.appDomain | quote }}
+spec:
+  policies:
+    circuitBreakers:
+      # Fast-fail when the Execution host is down instead of burning the 60s per-task
+      # invocation timeout N times inside the 300s job budget: 5 consecutive failures open
+      # the circuit for 30s, then a single probe request decides whether to close it.
+      # The breaker trips on connection failures and error responses alike, which is safe
+      # (it only short-circuits; it never re-invokes a task).
+      invocationBreaker:
+        maxRequests: 1
+        timeout: 30s
+        trip: consecutiveFailures >= 5
+  targets:
+    apps:
+      # Orchestration → Execution task invocation (RemoteInvokerService).
+      #
+      # NO retry policy on purpose. Dapr's service-invocation retry cannot distinguish an app
+      # response (the task ran and returned e.g. 500/4xx — which may already have produced side
+      # effects) from a transport failure (the sidecar never reached the app): both surface as
+      # an HTTP status with no reliable marker, and `matching.httpStatusCodes` filters by code,
+      # not by origin. A blanket retry would therefore re-invoke side-effecting tasks, and an
+      # empty/absent matching set retries ALL HTTP errors (>= 400) — the opposite of what a task
+      # invocation wants. So retry is owned entirely by the app layer: RemoteInvokerService turns
+      # a transport failure into a task failure that the user-defined error boundary decides on.
+      #
+      # No timeout policy on purpose: legitimate task calls run for tens of seconds; the
+      # app-level linked CTS (ExecutionApi:InvocationTimeoutSeconds, 60s) owns the per-call
+      # budget inside the hierarchy: 60s invocation ⊂ 300s job budget ⊂ 330s chain lock lease
+      # (validated at startup by WorkflowExecutionOptionsValidator).
+      #
+      # Cross-domain DirectTrigger targets have per-domain app-ids and cannot be enumerated
+      # here; add a circuitBreaker target entry per known remote domain when deploying multi-domain.
+      {{ printf "vnext-%s-execution-app" .Values.global.appDomain }}:
+        circuitBreaker: invocationBreaker

--- a/charts/vnext/templates/common/common-dapr-components/vnext-pubsub-template.yaml
+++ b/charts/vnext/templates/common/common-dapr-components/vnext-pubsub-template.yaml
@@ -1,0 +1,17 @@
+{{- range .Values.global.pubsubComponents }}
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: {{ .name }}
+spec:
+  type: {{ .spec.type }}
+  version: {{ .spec.version }}
+  metadata:
+  {{- range .spec.metadata }}
+    - name: {{ .name }}
+      value: {{ .value }}
+  {{- end }}
+scopes:
+- "vnext-{{ $.Values.global.appDomain }}-app"
+{{- end }}

--- a/charts/vnext/templates/common/common-dapr-components/vnext-subscription-template.yaml
+++ b/charts/vnext/templates/common/common-dapr-components/vnext-subscription-template.yaml
@@ -1,0 +1,32 @@
+{{- range .Values.global.subscriptionComponents }}
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: {{ .name }}
+scopes:
+- "vnext-{{ $.Values.global.appDomain }}-app"
+spec:
+  pubsubname: {{ .spec.pubsubname }}
+  topic: {{ .spec.topic }}
+  {{- if .spec.deadLetterTopic }}
+  deadLetterTopic: {{ .spec.deadLetterTopic }}
+  {{- end }}
+  routes:
+    {{- if .spec.routes.default }}
+    default: {{ .spec.routes.default }}
+    {{- end }}
+    {{- if .spec.routes.rules }}
+    rules:
+    {{- range .spec.routes.rules }}
+      - match: {{ .match | quote }}
+        path: {{ .path }}
+    {{- end }}
+    {{- end }}
+  {{- if .spec.metadata }}
+  metadata:
+    {{- range $k, $v := .spec.metadata }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/vnext/values.yaml
+++ b/charts/vnext/values.yaml
@@ -18,12 +18,42 @@ global:
     #       - name: url
     #         value: http://mocklab:3001/api/notification/sms
     # - name: state
-    #   spec: 
+    #   spec:
     #     type: bindings.http
     #     version: v1
     #     metadata:
     #       - name: url
     #         value: http://mocklab:3001/api/notification/state
+
+  # Dynamic pub/sub components for event-driven workflows.
+  # Each entry renders a Dapr Component scoped to the orchestrator (vnext-<appDomain>-app) sidecar.
+  # The component name is used verbatim; reference it from subscriptionComponents[].spec.pubsubname.
+  pubsubComponents: []
+    # - name: kafka-events
+    #   spec:
+    #     type: pubsub.kafka
+    #     version: v1
+    #     metadata:
+    #       - name: brokers
+    #         value: "kafka:9092"
+    #       - name: authType
+    #         value: none
+
+  # Dynamic subscriptions for event-driven workflows.
+  # Each entry renders a Dapr Subscription (v2alpha1) scoped to the orchestrator sidecar.
+  subscriptionComponents: []
+    # - name: order-created-sub
+    #   spec:
+    #     pubsubname: kafka-events          # must match a pubsubComponents[].name
+    #     topic: order.created
+    #     routes:
+    #       default: /events/order-created
+    #       # rules:
+    #       #   - match: 'event.type == "priority"'
+    #       #     path: /events/order-created-priority
+    #     # deadLetterTopic: order.created.DLQ
+    #     # metadata:
+    #     #   rawPayload: "true"
 
   # External Vault configuration
   # Use this when connecting to an existing HashiCorp Vault instance


### PR DESCRIPTION
## What & why

The chart previously rendered **no** `Resiliency` and **no** `Subscription` resources. This PR adds both, plus a values-driven mechanism for event-driven pub/sub, each attached to the correct Dapr sidecar.

### 1. Dapr Resiliency policies (always rendered)
Ported from the vNext runtime's self-hosted `resiliency.yaml` files, with app-ids now templated from `global.appDomain` and `scopes:` targeting the right sidecar (self-hosted relies on per-app component dirs; k8s needs explicit scopes).

| Resiliency | Scoped to (sidecar) | Protects | Target app |
|---|---|---|---|
| `vnext-orchestration-resiliency` | `vnext-<appDomain>-app` (orchestrator) | Orchestration → Execution task invocation | `vnext-<appDomain>-execution-app` |
| `vnext-inbox-resiliency` | `vnext-<appDomain>-worker-inbox-app` | Inbox → Orchestration forwards | `vnext-<appDomain>-app` |

Both use `invocationBreaker` (5 consecutive failures → open 30s → single probe). No retry/timeout policy on purpose — that ownership stays in the app layer (original rationale comments preserved).

### 2. Dynamic pub/sub + subscriptions
New `global.pubsubComponents` and `global.subscriptionComponents` lists (default `[]`), mirroring the existing `global.notificationComponents` pattern. Both render **scoped to the orchestrator (`vnext-<appDomain>-app`) sidecar**:
- Pub/sub → Dapr `Component`; the `name` is used **verbatim** so a subscription's `pubsubname` references it directly.
- Subscriptions → Dapr `Subscription` `v2alpha1` with `routes` (default + rules), optional `deadLetterTopic` and `metadata`.

## Files
- `templates/common/common-dapr-components/resiliency-{orchestration,inbox}.yaml` (new)
- `templates/common/common-dapr-components/vnext-{pubsub,subscription}-template.yaml` (new)
- `values.yaml` — new `global.pubsubComponents` / `global.subscriptionComponents` with commented examples
- `docs/README_EN.md`, `docs/README_TR.md` — new subsections

## Verification
- `helm lint charts/vnext` → **0 failed**
- Default render → only the two Resiliency resources with correct scopes/targets; no pubsub/subscription when lists empty
- `--set global.appDomain=banking` → scopes/targets become `vnext-banking-*`
- Sample values → `kind: Component` (`kafka-events`) + `kind: Subscription` (v2alpha1, `pubsubname: kafka-events`) both scoped to orchestrator

## Notes for reviewers
- `Chart.yaml` version is intentionally **not** bumped — the repo's CI `chore: bump chart version` automation handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add built-in Dapr resiliency policies and values-driven configuration for dynamic pub/sub components and subscriptions in the vnext Helm chart.

New Features:
- Introduce configurable Dapr pub/sub components via global.pubsubComponents values, scoped to the orchestrator sidecar.
- Introduce configurable Dapr Subscription resources via global.subscriptionComponents values, supporting routes, dead-letter topics, and metadata.

Enhancements:
- Add two default Dapr Resiliency policies that apply circuit breaker behavior between orchestrator, execution, and worker-inbox services using appDomain-derived app IDs.
- Document the new resiliency policies and event-driven pub/sub configuration in both English and Turkish chart READMEs.
- Extend values.yaml with commented examples that mirror the existing notificationComponents pattern for defining pub/sub and subscription resources from values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in Dapr resiliency policies with circuit-breaker protection for inbox and orchestration workflows.
  * Added configurable Dapr pub/sub components and topic subscriptions for event-driven workflows.
  * Added support for subscription routing, dead-letter topics, and metadata configuration.
  * New pub/sub and subscription settings default to empty, so no additional resources are created unless configured.

* **Documentation**
  * Updated English and Turkish documentation with resiliency and pub/sub configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->